### PR TITLE
always consume the entity even in case of failure

### DIFF
--- a/src/main/java/com/offbytwo/jenkins/client/JenkinsHttpClient.java
+++ b/src/main/java/com/offbytwo/jenkins/client/JenkinsHttpClient.java
@@ -138,10 +138,12 @@ public class JenkinsHttpClient {
         }
         HttpResponse response = client.execute(request, localContext);
         int status = response.getStatusLine().getStatusCode();
-        if (status < 200 || status >= 300) {
-            throw new HttpResponseException(status, response.getStatusLine().getReasonPhrase());
-        }
+       
         try {
+			if (status < 200 || status >= 300) {
+				throw new HttpResponseException(status, response.getStatusLine().getReasonPhrase());
+			}
+			
             if (cls != null) {
                 return objectFromResponse(cls, response);
             } else {


### PR DESCRIPTION
If you don't consume the response entity, the connection will not be
released.
In that case, you get a failure later on when making another request
using the same httpclient.
