### PR TITLE
Integration with Maven Artifacts API.

### DIFF
--- a/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
+++ b/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
@@ -92,6 +92,20 @@ public class JenkinsServer {
         }
 
     }
+    
+    public MavenJobWithDetails getMavenJob(String jobName) throws IOException {
+        try {
+            MavenJobWithDetails job = client.get("/job/"+encode(jobName), MavenJobWithDetails.class);
+            job.setClient(client);
+
+            return job;
+        } catch (HttpResponseException e) {
+            if(e.getStatusCode() == 404) {
+                return null;
+            }
+            throw e;
+        }
+    }
 
     /**
      * Create a job on the server using the provided xml

--- a/src/main/java/com/offbytwo/jenkins/model/MavenArtifact.java
+++ b/src/main/java/com/offbytwo/jenkins/model/MavenArtifact.java
@@ -1,0 +1,82 @@
+package com.offbytwo.jenkins.model;
+
+public class MavenArtifact extends BaseModel {
+    
+    String artifactId;
+    String canonicalName;
+    String classifier;
+    String fileName;
+    String groupId;
+    String md5sum;
+    String type;
+    String version;
+    
+    public MavenArtifact() {
+        
+    }
+    
+    public String getArtifactId() {
+        return artifactId;
+    }
+    
+    public void setArtifactId(String artifactId) {
+        this.artifactId = artifactId;
+    }
+    
+    public String getCanonicalName() {
+        return canonicalName;
+    }
+    
+    public void setCanonicalName(String canonicalName) {
+        this.canonicalName = canonicalName;
+    }
+    
+    public String getClassifier() {
+        return classifier;
+    }
+    
+    public void setClassifier(String classifier) {
+        this.classifier = classifier;
+    }
+    
+    public String getFileName() {
+        return fileName;
+    }
+    
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+    
+    public String getGroupId() {
+        return groupId;
+    }
+    
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+    
+    public String getMd5sum() {
+        return md5sum;
+    }
+    
+    public void setMd5sum(String md5sum) {
+        this.md5sum = md5sum;
+    }
+    
+    public String getType() {
+        return type;
+    }
+    
+    public void setType(String type) {
+        this.type = type;
+    }
+    
+    public String getVersion() {
+        return version;
+    }
+    
+    public void setVersion(String version) {
+        this.version = version;
+    }
+    
+}

--- a/src/main/java/com/offbytwo/jenkins/model/MavenBuild.java
+++ b/src/main/java/com/offbytwo/jenkins/model/MavenBuild.java
@@ -1,0 +1,24 @@
+package com.offbytwo.jenkins.model;
+
+import java.io.IOException;
+
+public class MavenBuild extends Build {
+    
+    public MavenBuild() {
+        
+    }
+    
+    public MavenBuild(Build from) {
+        this(from.getNumber(), from.getUrl());
+    }
+
+    public MavenBuild(int number, String url) {
+        super(number, url);
+    }
+    
+    public MavenModule getMavenModule() throws IOException {
+        return client.get(this.url + "/mavenArtifacts/", MavenModule.class);
+    }
+    
+}
+ 

--- a/src/main/java/com/offbytwo/jenkins/model/MavenJob.java
+++ b/src/main/java/com/offbytwo/jenkins/model/MavenJob.java
@@ -1,0 +1,19 @@
+package com.offbytwo.jenkins.model;
+
+import java.io.IOException;
+
+public class MavenJob extends Job {
+    
+    public MavenJob() {
+
+    }
+    
+    public MavenJob(String name, String url) {
+        super(name, url);
+    }
+    
+    public MavenJobWithDetails mavenDetails() throws IOException {
+        return client.get(getUrl(), MavenJobWithDetails.class);
+    }
+
+}

--- a/src/main/java/com/offbytwo/jenkins/model/MavenJobWithDetails.java
+++ b/src/main/java/com/offbytwo/jenkins/model/MavenJobWithDetails.java
@@ -1,0 +1,100 @@
+package com.offbytwo.jenkins.model;
+
+import java.util.List;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+
+public class MavenJobWithDetails extends MavenJob {
+
+    String displayName;
+    boolean buildable;
+    List<MavenBuild> builds;
+    MavenBuild lastBuild;
+    MavenBuild lastCompletedBuild;
+    MavenBuild lastFailedBuild;
+    MavenBuild lastStableBuild;
+    MavenBuild lastSuccessfulBuild;
+    MavenBuild lastUnstableBuild;
+    MavenBuild lastUnsuccessfulBuild;
+    int nextBuildNumber;
+    List<Job> downstreamProjects;
+    List<Job> upstreamProjects;
+    
+    public MavenJobWithDetails() {
+        
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public boolean isBuildable() {
+        return buildable;
+    }
+
+    public List<MavenBuild> getBuilds() {
+        return Lists.transform(builds, new Function<MavenBuild, MavenBuild>() {
+            @Override
+            public MavenBuild apply(MavenBuild from) {
+                return buildWithClient(from);
+            }
+        });
+    }
+    
+    public MavenBuild getLastBuild() {
+        return buildWithClient(lastBuild);
+    }
+
+    public MavenBuild getLastCompletedBuild() {
+        return buildWithClient(lastCompletedBuild);
+    }
+
+    public MavenBuild getLastFailedBuild() {
+        return buildWithClient(lastFailedBuild);
+    }
+    
+    public MavenBuild getLastStableBuild() {
+        return buildWithClient(lastStableBuild);
+    }
+
+    public MavenBuild getLastSuccessfulBuild() {
+        return buildWithClient(lastSuccessfulBuild);
+    }
+
+    public MavenBuild getLastUnstableBuild() {
+        return buildWithClient(lastUnstableBuild);
+    }
+
+    public MavenBuild getLastUnsuccessfulBuild() {
+        return buildWithClient(lastUnsuccessfulBuild);
+    }
+
+    public int getNextBuildNumber() {
+        return nextBuildNumber;
+    }
+
+    public List<Job> getDownstreamProjects() {
+        return Lists.transform(downstreamProjects, new MavenJobWithClient());
+    }
+
+    public List<Job> getUpstreamProjects() {
+        return Lists.transform(upstreamProjects, new MavenJobWithClient());
+    }
+    
+    private MavenBuild buildWithClient(MavenBuild from) {
+        MavenBuild ret = new MavenBuild(from);
+        ret.setClient(client);
+        return ret;
+    }
+    
+    private class MavenJobWithClient implements Function<Job, Job> {
+        @Override
+        public Job apply(Job job) {
+            job.setClient(client);
+            return job;
+        }
+    }
+    
+    
+}

--- a/src/main/java/com/offbytwo/jenkins/model/MavenModule.java
+++ b/src/main/java/com/offbytwo/jenkins/model/MavenModule.java
@@ -1,0 +1,13 @@
+package com.offbytwo.jenkins.model;
+
+import java.util.List;
+
+public class MavenModule extends BaseModel {
+    
+    List<MavenModuleRecord> moduleRecords;
+    
+    public List<MavenModuleRecord> getModuleRecords() {
+        return moduleRecords;
+    }
+
+}

--- a/src/main/java/com/offbytwo/jenkins/model/MavenModuleRecord.java
+++ b/src/main/java/com/offbytwo/jenkins/model/MavenModuleRecord.java
@@ -1,0 +1,57 @@
+package com.offbytwo.jenkins.model;
+
+import java.util.List;
+
+public class MavenModuleRecord extends BaseModel {
+    
+    List<MavenArtifact> attachedArtifacts;
+    Build parent;
+    MavenArtifact mainArtifact;
+    MavenArtifact pomArtifact;
+    String url;
+    
+    public MavenModuleRecord() {
+
+    }
+    
+    public List<MavenArtifact> getAttachedArtifacts() {
+        return attachedArtifacts;
+    }
+    
+    public void setAttachedArtifacts(List<MavenArtifact> attachedArtifacts) {
+        this.attachedArtifacts = attachedArtifacts;
+    }
+    
+    public Build getParent() {
+        return parent;
+    }
+    
+    public void setParent(Build parent) {
+        this.parent = parent;
+    }
+    
+    public MavenArtifact getMainArtifact() {
+        return mainArtifact;
+    }
+    
+    public void setMainArtifact(MavenArtifact mainArtifact) {
+        this.mainArtifact = mainArtifact;
+    }
+    
+    public MavenArtifact getPomArtifact() {
+        return pomArtifact;
+    }
+    
+    public void setPomArtifact(MavenArtifact pomArtifact) {
+        this.pomArtifact = pomArtifact;
+    }
+    
+    public String getUrl() {
+        return url;
+    }
+    
+    public void setUrl(String url) {
+        this.url = url;
+    }
+   
+}


### PR DESCRIPTION
Hi!

I was looking for retrieving some info about a Maven Project from a build (like the artifact's version number) when I came up with the `mavenArtifacts API`. I've added connectivity support to this API to the `JenkinsServer` interface and, in consequence, built 6 more model classes to support this new feature. 

Usage:

``` java
// get a reference from the Jenkins Server.
JenkinsServer jenkinsServer = new JenkinsServer("url", "user", "password");
// what's your job?
MavenJobWithDetails job = this.jenkinsServer.getMavenJob("my-job-name");
// get the maven module
MavenModule mavenModule = job.getLastBuild().getMavenModule();
// show then the last version.
System.out.println("Last version from the last build: " + mavenModule.getModuleRecords().get(0).getPomArtifact().getVersion());

```

Worked fine for my needs. I hope it became useful for someone.

Thanks for your job!
