### PR TITLE
expose addAuthentication and local context to subclasses

### DIFF
--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/client/JenkinsHttpClient.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/client/JenkinsHttpClient.java
@@ -36,6 +36,7 @@ import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.CoreConnectionPNames;
 import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.BasicHttpContext;
+import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,7 +62,7 @@ public class JenkinsHttpClient {
 
     private URI uri;
     private CloseableHttpClient client;
-    private BasicHttpContext localContext;
+    private HttpContext localContext;
     private HttpResponseValidator httpResponseValidator;
     // private HttpResponseContentExtractor contentExtractor;
 
@@ -161,7 +162,11 @@ public class JenkinsHttpClient {
      */
     public <T extends BaseModel> T get(String path, Class<T> cls) throws IOException {
         HttpGet getMethod = new HttpGet(api(path));
+        
+        System.out.println(getMethod.getURI());
+        System.out.println(getMethod.getRequestLine());
         HttpResponse response = client.execute(getMethod, localContext);
+        System.out.println(response.getStatusLine());
         getJenkinsVersionFromHeader(response);
         try {
             httpResponseValidator.validateResponse(response);
@@ -534,11 +539,11 @@ public class JenkinsHttpClient {
         return builder;
     }
 
-    protected BasicHttpContext getLocalContext() {
+    protected HttpContext getLocalContext() {
       return localContext;
     }
 
-    protected void setLocalContext(BasicHttpContext localContext) {
+    protected void setLocalContext(HttpContext localContext) {
       this.localContext = localContext;
     }
 }

--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/client/JenkinsHttpClient.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/client/JenkinsHttpClient.java
@@ -163,10 +163,7 @@ public class JenkinsHttpClient {
     public <T extends BaseModel> T get(String path, Class<T> cls) throws IOException {
         HttpGet getMethod = new HttpGet(api(path));
         
-        System.out.println(getMethod.getURI());
-        System.out.println(getMethod.getRequestLine());
         HttpResponse response = client.execute(getMethod, localContext);
-        System.out.println(response.getStatusLine());
         getJenkinsVersionFromHeader(response);
         try {
             httpResponseValidator.validateResponse(response);

--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/client/JenkinsHttpClient.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/client/JenkinsHttpClient.java
@@ -520,7 +520,7 @@ public class JenkinsHttpClient {
         httpRequestBase.releaseConnection();
     }
 
-    private static HttpClientBuilder addAuthentication(HttpClientBuilder builder, URI uri, String username,
+    protected static HttpClientBuilder addAuthentication(HttpClientBuilder builder, URI uri, String username,
             String password) {
         if (isNotBlank(username)) {
             CredentialsProvider provider = new BasicCredentialsProvider();
@@ -532,5 +532,13 @@ public class JenkinsHttpClient {
             builder.addInterceptorFirst(new PreemptiveAuth());
         }
         return builder;
+    }
+
+    protected BasicHttpContext getLocalContext() {
+      return localContext;
+    }
+
+    protected void setLocalContext(BasicHttpContext localContext) {
+      this.localContext = localContext;
     }
 }

--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/client/PreemptiveAuth.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/client/PreemptiveAuth.java
@@ -21,7 +21,7 @@ import org.apache.http.protocol.HttpContext;
 
 import java.io.IOException;
 
-class PreemptiveAuth implements HttpRequestInterceptor {
+public class PreemptiveAuth implements HttpRequestInterceptor {
 
     @Override
     public void process(HttpRequest request, HttpContext context) throws HttpException, IOException {


### PR DESCRIPTION
This is not an urgent or even necessary request.  Since it indicates something that's hard to do with the existing client implementation, I thought I should show you.  No problem if you want to close this.

I needed to change the SSL client, and found I could not change it while keeping basic auth in place.  With this PR its possible to extend the JenkinsHttpClient, and keep the authentication.  I needed the SSL client to skip cert validation, but still do basic auth.

Here's an ugly example.  Its quite ugly, and there's got to be a better way to do it.

https://gist.github.com/mcqueenorama/78ee0bd2cc3d2c993c6ec1585eb30af0