### PR TITLE
Move getTestReport method

### DIFF
--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/model/Build.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/model/Build.java
@@ -57,6 +57,10 @@ public class Build extends BaseModel {
         return client.get(url, BuildWithDetails.class);
     }
 
+    public TestReport getTestReport() throws IOException {
+        return client.get(this.getUrl() + "/testReport/?depth=1", TestReport.class);
+    }
+
     /*
      * This Change (Bad Practice) is due to inconsistencies in Jenkins various
      * versions. Jenkins changed their API from post to get and from get to post

--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/model/MavenBuild.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/model/MavenBuild.java
@@ -18,8 +18,4 @@ public class MavenBuild extends Build {
     public MavenModule getMavenModule() throws IOException {
         return client.get(this.getUrl() + "/mavenArtifacts/", MavenModule.class);
     }
-
-    public TestReport getTestReport() throws IOException {
-        return client.get(this.getUrl() + "/testReport/?depth=1", TestReport.class);
-    }
 }


### PR DESCRIPTION
As per #179 this pull request pushes the getTestReport method up from MavenBuild to Build as it isn't a Maven specific thing.