### PR TITLE
Calculate pass count and total count if they're missing from the Jenkins Api

### DIFF
--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/model/TestReport.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/model/TestReport.java
@@ -4,16 +4,27 @@ import java.util.List;
 
 /**
  * @author Karl Heinz Marbaise
- *
  */
 public class TestReport extends BaseModel {
 
     private int failCount;
     private int skipCount;
     private int totalCount;
+    private int passCount;
     private String urlName;
 
     private List<TestChildReport> childReports;
+
+    public int getPassCount() {
+        if (passCount == 0) {
+            passCount = totalCount - skipCount - failCount;
+        }
+        return passCount;
+    }
+
+    public void setPassCount(final int passCount) {
+        this.passCount = passCount;
+    }
 
     public int getFailCount() {
         return failCount;
@@ -32,6 +43,9 @@ public class TestReport extends BaseModel {
     }
 
     public int getTotalCount() {
+        if (totalCount == 0 && passCount > 0 || failCount > 0 || skipCount > 0) {
+            totalCount = passCount + failCount + skipCount;
+        }
         return totalCount;
     }
 
@@ -60,6 +74,7 @@ public class TestReport extends BaseModel {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((childReports == null) ? 0 : childReports.hashCode());
+        result = prime * result + passCount;
         result = prime * result + failCount;
         result = prime * result + skipCount;
         result = prime * result + totalCount;
@@ -81,6 +96,9 @@ public class TestReport extends BaseModel {
                 return false;
         } else if (!childReports.equals(other.childReports))
             return false;
+        if (passCount != other.passCount) {
+            return false;
+        }
         if (failCount != other.failCount)
             return false;
         if (skipCount != other.skipCount)

--- a/jenkins-client/src/test/java/com/offbytwo/jenkins/integration/BuildJobTestReports.java
+++ b/jenkins-client/src/test/java/com/offbytwo/jenkins/integration/BuildJobTestReports.java
@@ -35,6 +35,7 @@ public class BuildJobTestReports {
         System.out.println("    urlName: " + testReport.getUrlName());
         System.out.println("  failCount: " + testReport.getFailCount());
         System.out.println("  skipCount: " + testReport.getSkipCount());
+        System.out.println("  passCount: " + testReport.getPassCount());
         System.out.println(" totalCount: " + testReport.getTotalCount());
 
         List<TestChildReport> childReports = testReport.getChildReports();


### PR DESCRIPTION
 Add passCount as an attribute of TestReport. As this is a new element of the api, attempt to calculate pass count if it is 0 as it may be that the user of the library is using an older jenkins instance so passCount may not be available. totalCount is no longer available on the api of new releases of Jenkins so attempt to calculate this if 0
