### PR TITLE
methods with folders do use an absolute url

### DIFF
--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
@@ -481,7 +481,22 @@ public class JenkinsServer {
      * @throws IOException
      */
     public String getJobXml(String jobName) throws IOException {
-        return client.get("/job/" + EncodingUtils.encode(jobName) + "/config.xml");
+      return getJobXml(null,jobName);
+    }
+    
+    /**
+     * Get the xml description of an existing job
+     *
+     * @return the new job object
+     * @throws IOException
+     */
+    public String getJobXml(FolderJob folder, String jobName) throws IOException
+    {
+      String path = "/";
+      if (folder != null) {
+          path = folder.getUrl();
+      }
+      return client.get(path + "/job/" + EncodingUtils.encode(jobName) + "/config.xml");
     }
 
     /**
@@ -550,15 +565,33 @@ public class JenkinsServer {
     /**
      * Update the xml description of an existing job
      *
-     * @return the new job object
      * @throws IOException
      */
     public void updateJob(String jobName, String jobXml) throws IOException {
         this.updateJob(jobName, jobXml, true);
     }
 
+    /**
+     * Update the xml description of an existing job
+     *
+     * @throws IOException
+     */
     public void updateJob(String jobName, String jobXml, boolean crumbFlag) throws IOException {
-        client.post_xml("/job/" + EncodingUtils.encode(jobName) + "/config.xml", jobXml, crumbFlag);
+      updateJob(null,jobName,jobXml,crumbFlag);
+    }
+    
+    /**
+     * Update the xml description of an existing job
+     *
+     * @throws IOException
+     */
+    public void updateJob(FolderJob folder, String jobName, String jobXml, boolean crumbFlag) throws IOException
+    {
+      String path = "/";
+      if (folder != null) {
+          path = folder.getUrl();
+      }
+      client.post_xml(path + "/job/" + EncodingUtils.encode(jobName) + "/config.xml", jobXml, crumbFlag);
     }
 
     public void addStringParam(String jobName, String name, String description, String defaultValue)
@@ -617,10 +650,10 @@ public class JenkinsServer {
      * @throws IOException in case of problems.
      */
     public void deleteJob(FolderJob folder, String jobName, boolean crumbFlag) throws IOException {
-	String path = "/";
-	if (folder != null) {
-	    path = folder.getUrl();
-	}
+      String path = "/";
+      if (folder != null) {
+        path = folder.getUrl();
+      }
         client.post(path + "/job/" + EncodingUtils.encode(jobName) + "/doDelete", crumbFlag);
     }
 
@@ -759,7 +792,7 @@ public class JenkinsServer {
      *             In case of a failure.
      */
     public void renameJob(String oldJobName, String newJobName) throws IOException {
-	renameJob(null, oldJobName, newJobName, false);
+      renameJob(null, oldJobName, newJobName, false);
     }
 
     /**
@@ -775,7 +808,7 @@ public class JenkinsServer {
      *             In case of a failure.
      */
     public void renameJob(String oldJobName, String newJobName, Boolean crumbFlag) throws IOException {
-	renameJob(null, oldJobName, newJobName, crumbFlag);
+      renameJob(null, oldJobName, newJobName, crumbFlag);
     }
 
     /**
@@ -809,14 +842,12 @@ public class JenkinsServer {
      *             In case of a failure.
      */
     public void renameJob(FolderJob folder, String oldJobName, String newJobName, Boolean crumbFlag) throws IOException {
-	
+
         String path = "/";
         if (folder != null) {
             path = folder.getUrl();
         }
-	client.post( path + 
-		"job/" + EncodingUtils.encode(oldJobName) + "/doRename?newName=" + EncodingUtils.encodeParam(newJobName), crumbFlag);
-	
+        client.post( path + "job/" + EncodingUtils.encode(oldJobName) + "/doRename?newName=" + EncodingUtils.encodeParam(newJobName), crumbFlag);
     }
 
 }

--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
@@ -150,10 +150,7 @@ public class JenkinsServer {
      * @throws IOException
      */
     public Map<String, Job> getJobs(FolderJob folder, String view) throws IOException {
-        String path = "/";
-        if (folder != null) {
-            path = folder.getUrl();
-        }
+        String path = toBaseUrl(folder);
         Class<? extends MainView> viewClass = MainView.class;
         if (view != null) {
             path = path + "view/" + EncodingUtils.encode(view) + "/";
@@ -187,11 +184,7 @@ public class JenkinsServer {
      * @throws IOException
      */
     public Map<String, View> getViews(FolderJob folder) throws IOException {
-        String path = "/";
-        if (folder != null) {
-            path = folder.getUrl();
-        }
-        List<View> views = client.get(path + "?depth=1", MainView.class).getViews();
+        List<View> views = client.get(toBaseUrl(folder) + "?depth=1", MainView.class).getViews();
         return Maps.uniqueIndex(views, new Function<View, String>() {
             @Override
             public String apply(View view) {
@@ -232,13 +225,8 @@ public class JenkinsServer {
      * @throws IOException
      */
     public View getView(FolderJob folder, String name) throws IOException {
-        String path = "/";
-        if (folder != null) {
-            path = folder.getUrl();
-        }
-
         try {
-            View resultView = client.get(path + "view/" + EncodingUtils.encode(name) + "/", View.class);
+            View resultView = client.get(toViewBaseUrl(folder,name) + "/", View.class);
             resultView.setClient(client);
 
             //TODO: Think about the following? Does there exists a simpler/more elegant method?
@@ -276,12 +264,8 @@ public class JenkinsServer {
      * @throws IOException
      */
     public JobWithDetails getJob(FolderJob folder, String jobName) throws IOException {
-        String path = "/";
-        if (folder != null) {
-            path = folder.getUrl();
-        }
         try {
-            JobWithDetails job = client.get(path + "job/" + EncodingUtils.encode(jobName), JobWithDetails.class);
+            JobWithDetails job = client.get(toJobBaseUrl(folder,jobName), JobWithDetails.class);
             job.setClient(client);
 
             return job;
@@ -300,12 +284,8 @@ public class JenkinsServer {
     }
 
     public MavenJobWithDetails getMavenJob(FolderJob folder, String jobName) throws IOException {
-        String path = "/";
-        if (folder != null) {
-            path = folder.getUrl();
-        }
         try {
-            MavenJobWithDetails job = client.get(path + "job/" + EncodingUtils.encode(jobName),
+            MavenJobWithDetails job = client.get(toJobBaseUrl(folder, jobName),
                     MavenJobWithDetails.class);
             job.setClient(client);
 
@@ -377,11 +357,7 @@ public class JenkinsServer {
      * @throws IOException
      */
     public void createJob(FolderJob folder, String jobName, String jobXml, Boolean crumbFlag) throws IOException {
-        String path = "/";
-        if (folder != null) {
-            path = folder.getUrl();
-        }
-        client.post_xml(path + "createItem?name=" + EncodingUtils.encodeParam(jobName), jobXml, crumbFlag);
+        client.post_xml( toBaseUrl(folder) + "createItem?name=" + EncodingUtils.encodeParam(jobName), jobXml, crumbFlag);
     }
 
     /**
@@ -423,11 +399,7 @@ public class JenkinsServer {
      * @throws IOException
      */
     public void createView(FolderJob folder, String viewName, String viewXml, Boolean crumbFlag) throws IOException {
-        String path = "/";
-        if (folder != null) {
-            path = folder.getUrl();
-        }
-        client.post_xml(path + "createView?name=" + EncodingUtils.encodeParam(viewName), viewXml, crumbFlag);
+        client.post_xml(toBaseUrl(folder) + "createView?name=" + EncodingUtils.encodeParam(viewName), viewXml, crumbFlag);
     }
 
     /**
@@ -463,15 +435,11 @@ public class JenkinsServer {
      * @throws IOException
      */
     public void createFolder(FolderJob folder, String jobName, Boolean crumbFlag) throws IOException {
-        String path = "/";
-        if (folder != null) {
-            path = folder.getUrl();
-        }
         // https://gist.github.com/stuart-warren/7786892 was slightly helpful
         // here
         ImmutableMap<String, String> params = ImmutableMap.of("mode", "com.cloudbees.hudson.plugins.folder.Folder",
                 "name", EncodingUtils.encodeParam(jobName), "from", "", "Submit", "OK");
-        client.post_form(path + "createItem?", params, crumbFlag);
+        client.post_form(toBaseUrl(folder) + "createItem?", params, crumbFlag);
     }
 
     /**
@@ -492,11 +460,7 @@ public class JenkinsServer {
      */
     public String getJobXml(FolderJob folder, String jobName) throws IOException
     {
-      String path = "/";
-      if (folder != null) {
-          path = folder.getUrl();
-      }
-      return client.get(path + "/job/" + EncodingUtils.encode(jobName) + "/config.xml");
+      return client.get(toJobBaseUrl(folder, jobName) + "/config.xml");
     }
 
     /**
@@ -587,11 +551,7 @@ public class JenkinsServer {
      */
     public void updateJob(FolderJob folder, String jobName, String jobXml, boolean crumbFlag) throws IOException
     {
-      String path = "/";
-      if (folder != null) {
-          path = folder.getUrl();
-      }
-      client.post_xml(path + "/job/" + EncodingUtils.encode(jobName) + "/config.xml", jobXml, crumbFlag);
+      client.post_xml(toJobBaseUrl(folder, jobName) + "/config.xml", jobXml, crumbFlag);
     }
 
     public void addStringParam(String jobName, String name, String description, String defaultValue)
@@ -650,11 +610,7 @@ public class JenkinsServer {
      * @throws IOException in case of problems.
      */
     public void deleteJob(FolderJob folder, String jobName, boolean crumbFlag) throws IOException {
-      String path = "/";
-      if (folder != null) {
-        path = folder.getUrl();
-      }
-        client.post(path + "/job/" + EncodingUtils.encode(jobName) + "/doDelete", crumbFlag);
+        client.post(toJobBaseUrl(folder, jobName) + "/doDelete", crumbFlag);
     }
 
     /*
@@ -843,11 +799,41 @@ public class JenkinsServer {
      */
     public void renameJob(FolderJob folder, String oldJobName, String newJobName, Boolean crumbFlag) throws IOException {
 
-        String path = "/";
-        if (folder != null) {
-            path = folder.getUrl();
-        }
-        client.post( path + "job/" + EncodingUtils.encode(oldJobName) + "/doRename?newName=" + EncodingUtils.encodeParam(newJobName), crumbFlag);
+        client.post( toJobBaseUrl(folder, oldJobName) + "/doRename?newName=" + EncodingUtils.encodeParam(newJobName), crumbFlag);
+    }
+    
+    /**
+     * Helper to create a base url in case a folder is given 
+     * @param folder the folder or {@code null}
+     * @return
+     */
+    private String toBaseUrl(FolderJob folder)
+    {
+      String path = "/";
+      if (folder != null) {
+          path = folder.getUrl();
+      }
+      return path;
+    }
+
+    /**
+     * Helper to create the base url for a job, with or without a given folder 
+     * @param folder the folder or {@code null}
+     * @return
+     */
+    private String toJobBaseUrl(FolderJob folder, String jobName)
+    {
+      return toBaseUrl(folder) + "job/" + EncodingUtils.encode(jobName);
+    }
+
+    /**
+     * Helper to create the base url for a view, with or without a given folder 
+     * @param folder the folder or {@code null}
+     * @return
+     */
+    private String toViewBaseUrl(FolderJob folder, String name)
+    {
+      return toBaseUrl(folder) + "view/" + EncodingUtils.encode(name);
     }
 
 }

--- a/jenkins-client/src/test/java/com/offbytwo/jenkins/JenkinsServerTest.java
+++ b/jenkins-client/src/test/java/com/offbytwo/jenkins/JenkinsServerTest.java
@@ -76,7 +76,7 @@ public class JenkinsServerTest extends BaseUnitTest {
     	
     	String[] jobNames = { "job-the-first", "Job-The-Next", "Job-the-Next"};
         // given
-        String path = "http://localhost/jobs/someFolder/";
+        String path = "/job/someFolder/";
         Job someJob = new Job("jobname", path + "jobname");
         FolderJob folderJob = new FolderJob("someFolder", path);
 
@@ -100,7 +100,7 @@ public class JenkinsServerTest extends BaseUnitTest {
     @Test
     public void testFolderGetJob() throws Exception {
         // given
-        String path = "http://localhost/jobs/someFolder/";
+        String path = "/job/someFolder/";
         JobWithDetails someJob = mock(JobWithDetails.class);
         FolderJob folderJob = new FolderJob("someFolder", path);
 
@@ -117,7 +117,7 @@ public class JenkinsServerTest extends BaseUnitTest {
     @Test
     public void testFolderGetView() throws Exception {
         // given
-        String path = "http://localhost/jobs/someFolder/";
+        String path = "/job/someFolder/";
         FolderJob folderJob = new FolderJob("someFolder", path);
         View someView = mock(View.class);
 
@@ -134,7 +134,7 @@ public class JenkinsServerTest extends BaseUnitTest {
     @Test
     public void testGetFolderJob() throws Exception {
         // given
-        String path = "http://localhost/jobs/someFolder/";
+        String path = "/job/someFolder/";
         Job someJob = new Job("someFolder", path);
         FolderJob folderJob = mock(FolderJob.class);
 
@@ -152,7 +152,7 @@ public class JenkinsServerTest extends BaseUnitTest {
     @Test
     public void testGetFolderJobInvalidFolder() throws Exception {
         // given
-        String path = "http://localhost/jobs/someFolder/";
+        String path = "/job/someFolder/";
         Job someJob = new Job("someFolder", path);
         FolderJob folderJob = mock(FolderJob.class);
 
@@ -179,10 +179,10 @@ public class JenkinsServerTest extends BaseUnitTest {
     @Test
     public void testCreateSubFolderJob() throws Exception {
         // given
-        String path = "http://localhost/jobs/someFolder/";
+        String path = "/job/someFolder/";
         FolderJob folderJob = mock(FolderJob.class);
 
-        given(folderJob.getUrl()).willReturn(path);
+        given(folderJob.getRelativeUrl()).willReturn(path);
 
         // when
         server.createFolder(folderJob, "someFolder");
@@ -318,7 +318,7 @@ public class JenkinsServerTest extends BaseUnitTest {
 
     private void shouldGetFolderJobs(String... jobNames) throws IOException {
         // given
-        String path = "http://localhost/jobs/someFolder/";
+        String path = "/job/someFolder/";
         FolderJob folderJob = new FolderJob("someFolder", path);
 
         List<Job> someJobs = createTestJobs(path, jobNames);

--- a/jenkins-client/src/test/java/com/offbytwo/jenkins/model/JobTest.java
+++ b/jenkins-client/src/test/java/com/offbytwo/jenkins/model/JobTest.java
@@ -1,0 +1,16 @@
+package com.offbytwo.jenkins.model;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.*;
+
+public class JobTest
+{
+  @Test
+  public void testRelativeUrl() {
+    Job sut = new Job("job1", "http://jenkins3.example.net/job/data/job/bva-dudu-build/");
+    
+    assertThat(sut.getName()).isEqualTo("job1");
+    assertThat(sut.getUrl()).isEqualTo("http://jenkins3.example.net/job/data/job/bva-dudu-build/");
+    assertThat(sut.getRelativeUrl()).isEqualTo("/job/data/job/bva-dudu-build/");
+  }
+}


### PR DESCRIPTION
In our environment we need to access the jenkins (test) instance which an url that ist not the actual external url. So the jenkins server configuration does contain an external url the client cannot resolve. 
This did work because the client setup had the correct url and until now the lib used relative urls, honored the client setup url. But when using folders, the getFoldersJob() etc call does use job.getUrl() from a job instance previously retrived, which contains a 'wrong' external url! 

so this requests contains:
 * DISCLAIMER : also contains fixes for #203 because i based it on the refactorings from there
 * added getFolderJob(String) to retrive a FolderJob instance based on a folderPath (recursively) 
 * the method return null in case this is not a folder, which i think matches the getJob() contract better
