### PR TITLE
jenkins-client-213 - Added ability to get build for job name and number

### DIFF
--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
@@ -8,6 +8,7 @@ package com.offbytwo.jenkins;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 
@@ -762,6 +763,32 @@ public class JenkinsServer {
             job.setClient(client);
 
             return job;
+        } catch (HttpResponseException e) {
+            if (e.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Fetch build basing on jobName and build number
+     *
+     * @param jobName
+     * @param buildNumber
+     * @return Build object
+     *
+     * @throws IOException
+     * @throws URISyntaxException
+     */
+    public Build getBuild(String jobName, Long buildNumber) throws IOException, URISyntaxException {
+        try {
+            String url = new URI(jobName +"/" + buildNumber).toString();
+            Build build = client.get(url, Build.class);
+            if(build!=null){
+                build.setClient(client);
+            }
+            return build;
         } catch (HttpResponseException e) {
             if (e.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
                 return null;

--- a/jenkins-client/src/test/java/com/offbytwo/jenkins/JenkinsServerTest.java
+++ b/jenkins-client/src/test/java/com/offbytwo/jenkins/JenkinsServerTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import com.offbytwo.jenkins.model.*;
 import org.apache.http.entity.ContentType;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,11 +28,6 @@ import org.mockito.ArgumentCaptor;
 
 import com.google.common.base.Optional;
 import com.offbytwo.jenkins.client.JenkinsHttpClient;
-import com.offbytwo.jenkins.model.FolderJob;
-import com.offbytwo.jenkins.model.Job;
-import com.offbytwo.jenkins.model.JobWithDetails;
-import com.offbytwo.jenkins.model.MainView;
-import com.offbytwo.jenkins.model.View;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -112,6 +108,21 @@ public class JenkinsServerTest extends BaseUnitTest {
         // then
         verify(client).get(path + "job/jobname", JobWithDetails.class);
         assertEquals(someJob, jobResult);
+    }
+
+    @Test
+    public void testGetBuild() throws Exception {
+        // given
+        BuildWithDetails someBuild = mock(BuildWithDetails.class);
+
+        given(client.get(eq("job/1"), eq(Build.class))).willReturn(someBuild);
+
+        // when
+        Build build = server.getBuild("job", 1l);
+
+        // then
+        verify(client).get("job/1", Build.class);
+        assertEquals(someBuild, build);
     }
 
     @Test


### PR DESCRIPTION
## Motivation

Allow to fetch build (and artifacts) for provided job name and build number. 
Fetching queue item is not flexible as it's removed after the job is finished.

Resolves #213 