### PR TITLE
jenkins-client-217 - Added ability to stream logs and retrieve chunks

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,20 @@
 
 ## Release 0.3.8 (NOT RELEASED YET)
  
+ * [Fixed Issue 217][issue- 217]
+   
+   Added new api for streaming build logs
+
+   ```java
+    BuildWithDetails build = ...
+    // Get log with initial offset
+    int offset = 40;
+    String output = build.getConsoleOutputText(offset);
+    // Stream logs (when build is in progress)
+    BuildConsoleStreamListener buildListener = ...
+    build.streamConsoleOutput(listener, 3, 420);
+   ```
+
  * [Fixed Issue 222][issue-222]
    
    Fixed WARNING during build.

--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/helper/BuildConsoleStreamListener.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/helper/BuildConsoleStreamListener.java
@@ -1,0 +1,19 @@
+package com.offbytwo.jenkins.helper;
+
+/**
+ * Listener interface used to obtain build console logs
+ */
+public interface BuildConsoleStreamListener {
+
+    /**
+     * Called by api when new log data available.
+     *
+     * @param newLogChunk - string containing latest chunk of logs
+     */
+    void onData(String newLogChunk);
+
+    /**
+     * Called when streaming console output is finished
+     */
+     void finished();
+}

--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/model/ConsoleLog.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/model/ConsoleLog.java
@@ -1,0 +1,41 @@
+package com.offbytwo.jenkins.model;
+
+/**
+ * Represents build console log
+ */
+public class ConsoleLog {
+
+    private String consoleLog;
+    private Boolean hasMoreData;
+    private Integer currentBufferSize;
+
+    public ConsoleLog(String consoleLog, Boolean hasMoreData, Integer currentBufferSize) {
+        this.consoleLog = consoleLog;
+        this.hasMoreData = hasMoreData;
+        this.currentBufferSize = currentBufferSize;
+    }
+
+    public String getConsoleLog() {
+        return consoleLog;
+    }
+
+    public void setConsoleLog(String consoleLog) {
+        this.consoleLog = consoleLog;
+    }
+
+    public Boolean getHasMoreData() {
+        return hasMoreData;
+    }
+
+    public void setHasMoreData(Boolean hasMoreData) {
+        this.hasMoreData = hasMoreData;
+    }
+
+    public Integer getCurrentBufferSize() {
+        return currentBufferSize;
+    }
+
+    public void setCurrentBufferSize(Integer currentBufferSize) {
+        this.currentBufferSize = currentBufferSize;
+    }
+}

--- a/jenkins-client/src/test/java/com/offbytwo/jenkins/model/BuildWithDetailsTest.java
+++ b/jenkins-client/src/test/java/com/offbytwo/jenkins/model/BuildWithDetailsTest.java
@@ -1,0 +1,122 @@
+package com.offbytwo.jenkins.model;
+
+import com.offbytwo.jenkins.BaseUnitTest;
+import com.offbytwo.jenkins.client.JenkinsHttpClient;
+import com.offbytwo.jenkins.helper.BuildConsoleStreamListener;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHeader;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+
+/**
+ */
+public class BuildWithDetailsTest extends BaseUnitTest {
+
+    private JenkinsHttpClient client;
+    private BuildWithDetails buildWithDetails;
+
+    @Before
+    public void setUp() {
+        client = mock(JenkinsHttpClient.class);
+        buildWithDetails = givenBuild();
+    }
+
+    private BuildWithDetails givenBuild() {
+        BuildWithDetails buildWithDetails = new BuildWithDetails();
+        buildWithDetails.setClient(client);
+        return buildWithDetails;
+    }
+
+    @Test
+    public void getBuildLogWithBuffer() {
+        try {
+            HttpResponse response = mock(HttpResponse.class);
+            String text = "test test test";
+            int textLength = text.length();
+            given(response.getEntity()).willReturn(new StringEntity(text));
+            BasicHeader moreDataHeader = new BasicHeader(BuildWithDetails.MORE_DATA_HEADER, "false");
+            BasicHeader textSizeHeader = new BasicHeader(BuildWithDetails.TEXT_SIZE_HEADER, Integer.toString(textLength));
+            given(response.getFirstHeader(BuildWithDetails.MORE_DATA_HEADER)).willReturn(moreDataHeader);
+            given(response.getFirstHeader(BuildWithDetails.TEXT_SIZE_HEADER)).willReturn(textSizeHeader);
+            given(client.post_form_with_result(anyString(),anyListOf(NameValuePair.class),anyBoolean())).willReturn(response);
+            ConsoleLog consoleOutputText = buildWithDetails.getConsoleOutputText(500);
+            assertThat(consoleOutputText.getConsoleLog()).isEqualTo(text);
+            assertThat(consoleOutputText.getCurrentBufferSize()).isEqualTo(textLength);
+            assertThat(consoleOutputText.getHasMoreData()).isFalse();
+        } catch (IOException e) {
+            fail("Should not return exception",e);
+        }
+    }
+
+
+    @Test
+    public void poolBuildLog() throws InterruptedException {
+        try {
+            HttpResponse response = mock(HttpResponse.class);
+            final String text = "test test test";
+            int textLength = text.length();
+            given(response.getEntity()).willReturn(new StringEntity(text));
+            BasicHeader moreDataHeader = new BasicHeader(BuildWithDetails.MORE_DATA_HEADER, "false");
+            BasicHeader textSizeHeader = new BasicHeader(BuildWithDetails.TEXT_SIZE_HEADER, Integer.toString(textLength));
+            given(response.getFirstHeader(BuildWithDetails.MORE_DATA_HEADER)).willReturn(moreDataHeader);
+            given(response.getFirstHeader(BuildWithDetails.TEXT_SIZE_HEADER)).willReturn(textSizeHeader);
+            given(client.post_form_with_result(anyString(),anyListOf(NameValuePair.class),anyBoolean())).willReturn(response);
+            final StringBuffer buffer=new StringBuffer();
+            buildWithDetails.streamConsoleOutput(new BuildConsoleStreamListener() {
+                @Override
+                public void onData(String newLogChunk) {
+                    assertThat(newLogChunk).isEqualTo(text);
+                    buffer.append(text);
+                }
+
+                @Override
+                public void finished() {
+                    assertThat(buffer.toString()).isEqualTo(text);
+                }
+            },1,2);
+        } catch (IOException e) {
+            fail("Should not return exception",e);
+        }
+    }
+
+    @Test
+    public void poolBuildLogShouldTimeout() throws InterruptedException {
+        try {
+            HttpResponse response = mock(HttpResponse.class);
+            final String text = "test test test";
+            int textLength = text.length();
+            given(response.getEntity()).willReturn(new StringEntity(text));
+            BasicHeader moreDataHeader = new BasicHeader(BuildWithDetails.MORE_DATA_HEADER, "true");
+            BasicHeader textSizeHeader = new BasicHeader(BuildWithDetails.TEXT_SIZE_HEADER, Integer.toString(textLength));
+            given(response.getFirstHeader(BuildWithDetails.MORE_DATA_HEADER)).willReturn(moreDataHeader);
+            given(response.getFirstHeader(BuildWithDetails.TEXT_SIZE_HEADER)).willReturn(textSizeHeader);
+            given(client.post_form_with_result(anyString(),anyListOf(NameValuePair.class),anyBoolean())).willReturn(response);
+            buildWithDetails.streamConsoleOutput(new BuildConsoleStreamListener() {
+                @Override
+                public void onData(String newLogChunk) {
+                    assertThat(newLogChunk).isEqualTo(text);
+                }
+
+                @Override
+                public void finished() {
+                    fail("Should timeout");
+                }
+            },1,2);
+        } catch (IOException e) {
+            fail("Should not return exception",e);
+        }
+    }
+
+}


### PR DESCRIPTION
## Motivation

Allow to stream logs for ongoing builds.
Current methods doesn't allow that and users need to wait for entire build to get full build log.

This PR is implementation for #217