### PR TITLE
add "getClient" helper method for use in JenkinsServer subclasses

### DIFF
--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
@@ -882,6 +882,13 @@ public class JenkinsServer {
     }
 
     /**
+     * @return current JenkinsHttpClient instance
+     */
+    protected JenkinsHttpClient getClient() {
+        return client;
+    }
+
+    /**
      * Helper to create a base url in case a folder is given
      * 
      * @param folder the folder or {@code null}


### PR DESCRIPTION
This PR adds a protected `getClient` method to allow subclasses of `JenkinsServer` to use the client directly.

Use case: In my project I have some custom functionality I'd like to add to `JenkinsServer` in a subclass. Unfortunately the `JenkinsHttpClient client` property is private, so I'm forced to initialize a second instance in my subclass. 