### PR TITLE
Disable redirect handling for cyclical redirects from remote environments

### DIFF
--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/client/JenkinsHttpClient.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/client/JenkinsHttpClient.java
@@ -515,7 +515,8 @@ public class JenkinsHttpClient {
             UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(username, password);
             provider.setCredentials(scope, credentials);
             builder.setDefaultCredentialsProvider(provider);
-
+            builder.disableRedirectHandling();
+            
             builder.addInterceptorFirst(new PreemptiveAuth());
         }
         return builder;


### PR DESCRIPTION
Disabling the redirect handling to prevent an exception being thrown when the Jenkins API returns a cyclical redirect.

See #235.