### PR TITLE
Add support for retrieving jobs by fullName (also return fullName on the Job)

### DIFF
--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
@@ -8,6 +8,8 @@ package com.offbytwo.jenkins;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -260,7 +262,7 @@ public class JenkinsServer {
      * @throws IOException in case of an error.
      */
     public JobWithDetails getJob(String jobName) throws IOException {
-        return getJob(null, jobName);
+        return getJob(null, parseFullName(jobName));
     }
 
     /**
@@ -288,7 +290,7 @@ public class JenkinsServer {
     }
 
     public MavenJobWithDetails getMavenJob(String jobName) throws IOException {
-        return getMavenJob(null, jobName);
+        return getMavenJob(null, parseFullName(jobName));
     }
 
     public MavenJobWithDetails getMavenJob(FolderJob folder, String jobName) throws IOException {
@@ -562,7 +564,6 @@ public class JenkinsServer {
     /**
      * Update the xml description of an existing view
      *
-     * @throws IOException in case of an error.
      * @param viewName name of the view.
      * @param viewXml the view configuration.
      * @throws IOException in case of an error.
@@ -903,7 +904,18 @@ public class JenkinsServer {
      * @return converted base url.
      */
     private String toJobBaseUrl(FolderJob folder, String jobName) {
-        return toBaseUrl(folder) + "job/" + EncodingUtils.encode(jobName);
+        String jobBaseUrl = toBaseUrl(folder) + "job/";
+        
+        String[] jobNameParts = jobName.split("/");
+        for (int i = 0; i < jobNameParts.length; i++) {
+            jobBaseUrl += EncodingUtils.encode(jobNameParts[i]);
+            
+            if (i != jobNameParts.length - 1) {
+                jobBaseUrl += "/";
+            }
+        }
+        
+        return jobBaseUrl;
     }
 
     /**
@@ -917,4 +929,29 @@ public class JenkinsServer {
         return toBaseUrl(folder) + "view/" + EncodingUtils.encode(name);
     }
 
+    /**
+     * Parses the provided job name for folders to get the full path for the job.
+     * @param jobName the fullName of the job.
+     * @return the path of the job including folders if present.
+     */
+    private String parseFullName(String jobName)
+    {
+        if (!jobName.contains("/")) {
+            return jobName;
+        }
+        
+        List<String> foldersAndJob = Arrays.asList(jobName.split("/"));
+        
+        String foldersAndJobName = "";
+        
+        for (int i = 0; i < foldersAndJob.size(); i++) {
+            foldersAndJobName += foldersAndJob.get(i);
+            
+            if (i != foldersAndJob.size() -1) {
+                foldersAndJobName += "/job/";
+            }
+        }
+        
+        return foldersAndJobName;
+    }
 }

--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/model/FolderJob.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/model/FolderJob.java
@@ -20,6 +20,10 @@ public class FolderJob extends Job {
     public FolderJob(String name, String url) {
         super(name, url);
     }
+    
+    public FolderJob(String name, String url, String fullName) {
+        super(name, url, fullName);
+    }
 
     public String getDisplayName() {
         return displayName;

--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/model/Job.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/model/Job.java
@@ -23,14 +23,23 @@ public class Job extends BaseModel {
 
     private String name;
     private String url;
+    private String fullName;
 
     public Job() {
     }
-
+    
     public Job(String name, String url) {
         this();
         this.name = name;
         this.url = url;
+        this.fullName = null;
+    }
+
+    public Job(String name, String url, String fullName) {
+        this();
+        this.name = name;
+        this.url = url;
+        this.fullName = fullName;
     }
 
     public String getName() {
@@ -39,6 +48,10 @@ public class Job extends BaseModel {
 
     public String getUrl() {
         return url;
+    }
+    
+    public String getFullName() {
+        return fullName;
     }
 
     public JobWithDetails details() throws IOException {
@@ -126,6 +139,8 @@ public class Job extends BaseModel {
             return false;
         if (url != null ? !url.equals(job.url) : job.url != null)
             return false;
+        if (fullName != null ? !fullName.equals(job.fullName) : job.fullName != null)
+            return false;
 
         return true;
     }
@@ -133,7 +148,7 @@ public class Job extends BaseModel {
     @Override
     public int hashCode() {
         int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (url != null ? url.hashCode() : 0);
+        result = 31 * result + (url != null ? url.hashCode() : 0) + (fullName != null ? fullName.hashCode() : 0);
         return result;
     }
 

--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/model/JobWithDetails.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/model/JobWithDetails.java
@@ -59,7 +59,7 @@ public class JobWithDetails extends Job {
     private List<Job> downstreamProjects;
 
     private List<Job> upstreamProjects;
-
+    
     public String getDescription() {
         return description;
     }

--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/model/MavenJob.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/model/MavenJob.java
@@ -10,6 +10,10 @@ public class MavenJob extends Job {
     public MavenJob(String name, String url) {
         super(name, url);
     }
+    
+    public MavenJob(String name, String url, String fullName) {
+        super(name, url, fullName);
+    }
 
     public MavenJobWithDetails mavenDetails() throws IOException {
         return client.get(getUrl(), MavenJobWithDetails.class);


### PR DESCRIPTION
To retrieve jobs that are within one or more FolderJob(s), we must parse the job's fullName to correctly format the folder jobs for the http request. 

See Issue #254.