### PR TITLE
Fixed #45284 JenkinsTriggerHelper can wait for too long if job allows concurrent builds

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,10 @@
 
 ## Release 0.3.8 (NOT RELEASED YET)
 
+* [Fixed Issue 45284][jissue-45284]
+
+   JenkinsTriggerHelper can wait for too long if job allows concurrent builds.
+
 * [Fixed Issue 98][issue-98]
    
    Splitting fix made for jacoco reports from Jenkins #98.

--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/JenkinsTriggerHelper.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/JenkinsTriggerHelper.java
@@ -86,7 +86,7 @@ public class JenkinsTriggerHelper {
         JobWithDetails job = this.server.getJob(jobName);
         QueueReference queueRef = job.build(params, crumbFlag);
 
-        return triggerJobAndWaitUntilFinished(jobName, queueRef);
+        return triggerJobAndWaitUntilFinished(queueRef);
     }
 
     /**
@@ -107,11 +107,10 @@ public class JenkinsTriggerHelper {
         JobWithDetails job = this.server.getJob(jobName);
         QueueReference queueRef = job.build(crumbFlag);
 
-        return triggerJobAndWaitUntilFinished(jobName, queueRef);
+        return triggerJobAndWaitUntilFinished(queueRef);
     }
 
     /**
-     * @param jobName The name of the job.
      * @param queueRef {@link QueueReference}
      * @return In case of an cancelled job you will get
      *         {@link BuildWithDetails#getResult()}
@@ -120,14 +119,13 @@ public class JenkinsTriggerHelper {
      * @throws IOException in case of errors.
      * @throws InterruptedException In case of interrupts.
      */
-    private BuildWithDetails triggerJobAndWaitUntilFinished(String jobName, QueueReference queueRef)
+    private BuildWithDetails triggerJobAndWaitUntilFinished(QueueReference queueRef)
             throws IOException, InterruptedException {
-        JobWithDetails job = this.server.getJob(jobName);
         QueueItem queueItem = this.server.getQueueItem(queueRef);
 
-        while (!queueItem.isCancelled() && job.isInQueue()) {
+        while (!queueItem.isCancelled()
+               && (queueItem.getExecutable() == null || queueItem.getExecutable().getNumber() == null)) {
             Thread.sleep(retryInterval);
-            job = this.server.getJob(jobName);
             queueItem = this.server.getQueueItem(queueRef);
         }
 


### PR DESCRIPTION
 o JenkinsTriggerHelper can wait for too long if job allows
   concurrent builds.