### PR TITLE
JENKINS-46445 Add support for both client TLS and basic authentication.

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,17 @@
 
 ## Release 0.3.8 (NOT RELEASED YET)
 
+ * [JENKINS-46445](https://issues.jenkins-ci.org/browse/JENKINS-46445)
+
+   Add support for both client TLS and basic authentication.
+
+   ```java
+    HttpClientBuilder builder = HttpClientBuilder.create();
+    builder.setSslcontext(sslContext);
+    JenkinsHttpClient client = new JenkinsHttpClient(uri, builder, username, password);
+    JenkinsServer jenkins = new JenkinsServer(client);
+   ```
+
  * [Fixed Issue 268][issue-268]
   
    NullPointerException is thrown unless isRunning() is called first.

--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/client/JenkinsHttpClient.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/client/JenkinsHttpClient.java
@@ -115,7 +115,19 @@ public class JenkinsHttpClient {
      * @param password Password or auth token to use when connecting
      */
     public JenkinsHttpClient(URI uri, String username, String password) {
-        this(uri, addAuthentication(HttpClientBuilder.create(), uri, username, password));
+        this(uri, HttpClientBuilder.create(), username, password);
+    }
+
+    /**
+     * Create an authenticated Jenkins HTTP client
+     *
+     * @param uri Location of the jenkins server (ex. http://localhost:8080)
+     * @param builder Configured HttpClientBuilder to be used
+     * @param username Username to use when connecting
+     * @param password Password or auth token to use when connecting
+     */
+    public JenkinsHttpClient(URI uri, HttpClientBuilder builder, String username, String password) {
+        this(uri, addAuthentication(builder, uri, username, password));
         if (isNotBlank(username)) {
             localContext = new BasicHttpContext();
             localContext.setAttribute("preemptive-auth", new BasicScheme());


### PR DESCRIPTION
In some setups both client certificate TLS authentication and
username password authentication is needed.

Here is how you would set it up.

Create a sslContext, and add it along with credentials this way
```
HttpClientBuilder builder = HttpClientBuilder.create();
builder.setSslcontext(sslContext);
JenkinsHttpClient client = new JenkinsHttpClient(uri, builder, username, password);
JenkinsServer jenkins = new JenkinsServer(client);
```