### PR TITLE
Fixed #282

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,11 @@
 
 ## Release 0.3.8 (NOT RELEASED YET)
 
+ * [Fixed Issue 282][issue-282]
+   
+   `NullPointerException` may be thrown if `upstreamUrl` is `null` when
+   converting cause to `BuildCause` object.
+
  * [Fixed Issue 268][issue-268]
   
    NullPointerException is thrown unless isRunning() is called first.

--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/model/BuildWithDetails.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/model/BuildWithDetails.java
@@ -290,7 +290,7 @@ public class BuildWithDetails extends Build {
         }
 
         String upstreamUrl = (String) cause.get("upstreamUrl");
-        if (!Strings.isNullOrEmpty(upstreamProject)) {
+        if (!Strings.isNullOrEmpty(upstreamUrl)) {
             cause_object.setUpstreamUrl(upstreamUrl);
         }
 


### PR DESCRIPTION
Check the correct parameter before setting it in the BuildCause object to prevent NPE.
