### PR TITLE
Fixed Issue#289 Add a Build.stopPost with a crumbFlag version

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,10 @@
 
 ## Release 0.3.8 (NOT RELEASED YET)
 
+ * [Fixed Issue 289][issue-289]
+   
+   Added a build.stop() method which takes in a crumbFlag
+
 
  * [Fixed Issue 301][issue-301]
    

--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/model/Build.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/model/Build.java
@@ -149,6 +149,33 @@ public class Build extends BaseModel {
         return "";
     }
 
+    /** Stops the build which is currently in progress.  This version takes in
+     * a crumbFlag.  In some cases , an error is thrown which reads
+     * "No valid crumb was included in the request".  This stop method is used incase
+     * those issues occur
+     *
+     * @param crumbFlag flag used to specify if a crumb is passed into for the request
+     * @return the client url
+     * @throws HttpResponseException
+     * @throws IOException
+     */
+    public String Stop(boolean crumbFlag) throws HttpResponseException, IOException {
+        try {
+
+            return client.get(url + "stop");
+        } catch (IOException ex) {
+            if (((HttpResponseException) ex).getStatusCode() == 405) {
+                stopPost(crumbFlag);
+                return "";
+            }
+        }
+        return "";
+    }
+
+    private void stopPost(boolean crumbFlag) throws HttpResponseException, IOException {
+        client.post(url + "stop", crumbFlag);
+    }
+
     private void stopPost() throws HttpResponseException, IOException {
         client.post(url + "stop");
     }


### PR DESCRIPTION
Added a method to invoke Build.stopPost() where a crumbFlag is passed in.  The issue which addresses this pull request is here: 

https://github.com/jenkinsci/java-client-api/issues/289

@khmarbaise