### PR TITLE
Fixed #321 handle change set lists

### DIFF
--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/model/BuildWithDetails.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/model/BuildWithDetails.java
@@ -6,6 +6,7 @@
 
 package com.offbytwo.jenkins.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
@@ -124,6 +125,8 @@ public class BuildWithDetails extends Build {
     private String consoleOutputText;
     private String consoleOutputHtml;
     private BuildChangeSet changeSet;
+    @JsonProperty("changeSets")
+    private List<BuildChangeSet> changeSets;
     private String builtOn;
     private List<BuildChangeSetAuthor> culprits;
 
@@ -467,12 +470,54 @@ public class BuildWithDetails extends Build {
     }
 
 
+  /**
+   * Returns the change set of a build if available.
+   * 
+   * If a build performs several scm checkouts (i.e. pipeline builds), the change set of the first
+   * checkout is returned. To get the complete list of change sets for all checkouts, use
+   * {@link #getChangeSets()}
+   * 
+   * If no checkout is performed, null is returned.
+   * 
+   * @return The change set of the build.
+   * 
+   */
     public BuildChangeSet getChangeSet() {
-        return changeSet;
+        BuildChangeSet result;
+        if (changeSet != null) {
+            result = changeSet;
+        } else if (changeSets != null && !changeSets.isEmpty()) {
+            result = changeSets.get(0);
+        } else {
+            result = null;
+        }
+        return result;
     }
 
     public void setChangeSet(BuildChangeSet changeSet) {
         this.changeSet = changeSet;
+    }
+
+  /**
+   * Returns the complete list of change sets for all checkout the build has performed. If no
+   * checkouts have been performed, returns null.
+   * 
+   * @return The complete list of change sets of the build.
+   */
+    public List<BuildChangeSet> getChangeSets() {
+        List<BuildChangeSet> result;
+        if (changeSets != null) {
+            result = changeSets;
+        } else if (changeSet != null) {
+            result = Collections.singletonList(changeSet);
+        } else {
+            result = null;
+	}
+        return result;
+    }
+
+    public void setChangeSets(List<BuildChangeSet> changeSets) {
+        this.changeSets = changeSets;
     }
 
     public List<BuildChangeSetAuthor> getCulprits() {
@@ -527,6 +572,11 @@ public class BuildWithDetails extends Build {
             if (other.changeSet != null)
                 return false;
         } else if (!changeSet.equals(other.changeSet))
+            return false;
+        if (changeSets == null) {
+            if (other.changeSets != null)
+                return false;
+        } else if (!changeSets.equals(other.changeSets))
             return false;
         if (consoleOutputHtml == null) {
             if (other.consoleOutputHtml != null)
@@ -583,6 +633,7 @@ public class BuildWithDetails extends Build {
         result = prime * result + (building ? 1231 : 1237);
         result = prime * result + ((builtOn == null) ? 0 : builtOn.hashCode());
         result = prime * result + ((changeSet == null) ? 0 : changeSet.hashCode());
+        result = prime * result + ((changeSets == null) ? 0 : changeSets.hashCode());
         result = prime * result + ((consoleOutputHtml == null) ? 0 : consoleOutputHtml.hashCode());
         result = prime * result + ((consoleOutputText == null) ? 0 : consoleOutputText.hashCode());
         result = prime * result + ((culprits == null) ? 0 : culprits.hashCode());

--- a/jenkins-client/src/test/java/com/offbytwo/jenkins/model/ChangeSetTest.java
+++ b/jenkins-client/src/test/java/com/offbytwo/jenkins/model/ChangeSetTest.java
@@ -1,0 +1,74 @@
+package com.offbytwo.jenkins.model;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static org.junit.Assert.*;
+
+
+import org.junit.Test;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ChangeSetTest {
+
+    private BuildWithDetails getBuildFromJson(String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(FAIL_ON_UNKNOWN_PROPERTIES);
+        return mapper.readValue(json, BuildWithDetails.class);
+    }
+
+    final String changeSetExampleJson = "    {" + 
+            "      \"_class\" : \"hudson.plugins.git.GitChangeSetList\"," + 
+            "      \"items\" : [" + 
+            "        {" + 
+            "          \"_class\" : \"hudson.plugins.git.GitChangeSet\"," + 
+            "          \"affectedPaths\" : [" + 
+            "            \"README.md\"" + 
+            "          ]," + 
+            "          \"commitId\" : \"ba40ff32c60f692918c1d51f5c80842124ed04af\"," + 
+            "          \"timestamp\" : 1519306808000," + 
+            "          \"author\" : {" + 
+            "            \"absoluteUrl\" : \"https://my.jenkins/user/john.doe\","
+            + "            \"fullName\" : \"john.doe\"" +
+            "          }," + 
+            "          \"authorEmail\" : \"john.doe@flap.com\","
+            + 
+            "          \"comment\" : \"longer\\ncommit message\\n\"," + 
+            "          \"date\" : \"2018-02-22 13:40:08 +0000\"," + 
+            "          \"id\" : \"ba40ff32c60f692918c1d51f5c80842124ed04af\"," + 
+            "          \"msg\" : \"longer\"," + 
+            "          \"paths\" : [" + 
+            "            {" + 
+            "              \"editType\" : \"edit\"," + 
+            "              \"file\" : \"README.md\"" + 
+            "            }" + 
+            "          ]" + 
+            "        }" + 
+            "      ]," + 
+            "      \"kind\" : \"git\"" + 
+            "    }";
+            
+
+    @Test
+    public void getChangeSet__forBuildWithChangeSetAsSingleObject() throws Exception {
+        String json = String.format("{ \"changeSet\" : %s }", changeSetExampleJson);
+
+        BuildWithDetails examinee = getBuildFromJson(json);
+
+        BuildChangeSetItem item = examinee.getChangeSet().getItems().get(0);
+        assertEquals(item.getAuthor().getFullName(), "john.doe");
+
+    }
+
+    @Test
+    public void getChangeSet__forBuildWithChangeSetsAsList() throws Exception {
+        String json = String.format("{ \"changeSets\" : [ %s ] }", changeSetExampleJson);
+
+        BuildWithDetails examinee = getBuildFromJson(json);
+
+        BuildChangeSetItem item = examinee.getChangeSet().getItems().get(0);
+        assertEquals(item.getAuthor().getFullName(), "john.doe");
+
+        assertEquals(examinee.getChangeSets().size(), 1);
+    }
+}


### PR DESCRIPTION
pipeline builds present change sets as list, because there can be several
checkouts.

We add a further filed+getter such that this data gets deserialized.