### PR TITLE
Fixed# #243 Support for Stopping and Restarting Jenkins

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -16,7 +16,7 @@
 
 ### API Changes
 
- * [Fixed Issue 243][issue-243] 
+ * [Fixed Issue 243](https://github.com/jenkinsci/java-client-api/issues/243) 
  
     Added new methods to JenkinsServer for stopping and restarting Jenkins. The methods are restart(Boolean crumbFlag), safeRestart(Boolean crumbFlag), exit(Boolean crumbFlag) and safeExit(Boolean crumbFlag)
 	

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -16,8 +16,12 @@
 
 ### API Changes
 
- * ?
-
+ * [Fixed Issue 243][issue-243] 
+ 
+    Added new methods to JenkinsServer for stopping and restarting Jenkins. The methods are restart(Boolean crumbFlag), safeRestart(Boolean crumbFlag), exit(Boolean crumbFlag) and safeExit(Boolean crumbFlag)
+	
+	Thanks for that to [Chids](https://github.com/Chids-gs).
+	
 ## Release 0.3.7
 
  * Changed Eclipse Formatting configuration.

--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
@@ -917,4 +917,74 @@ public class JenkinsServer {
         return toBaseUrl(folder) + "view/" + EncodingUtils.encode(name);
     }
 
+	/**
+	 * Restart Jenkins without waiting for any existing build to complete
+	 * 
+	 * @param crumbFlag
+	 *            <code>true</code> to add <b>crumbIssuer</b> <code>false</code>
+	 *            otherwise.
+	 * @throws IOException
+	 *             in case of an error.
+	 */
+	public void restart(Boolean crumbFlag) throws IOException {
+		try {
+			client.post("/restart", crumbFlag);
+		} catch (org.apache.http.client.ClientProtocolException e) {
+			LOGGER.error("restart()", e);
+		}
+	}
+
+	/**
+	 * safeRestart: Puts Jenkins into the quiet mode, wait for existing builds
+	 * to be completed, and then restart Jenkins
+	 * 
+	 * @param crumbFlag
+	 *            <code>true</code> to add <b>crumbIssuer</b> <code>false</code>
+	 *            otherwise.
+	 * @throws IOException
+	 *             in case of an error.
+	 */
+	public void safeRestart(Boolean crumbFlag) throws IOException {
+		try {
+			client.post("/safeRestart", crumbFlag);
+		} catch (org.apache.http.client.ClientProtocolException e) {
+			LOGGER.error("safeRestart()", e);
+		}
+	}
+
+	/**
+	 * Shutdown Jenkins without waiting for any existing build to complete
+	 * 
+	 * @param crumbFlag
+	 *            <code>true</code> to add <b>crumbIssuer</b> <code>false</code>
+	 *            otherwise.
+	 * @throws IOException
+	 *             in case of an error.
+	 */
+	//
+	public void exit(Boolean crumbFlag) throws IOException {
+		try {
+			client.post("/exit", crumbFlag);
+		} catch (org.apache.http.client.ClientProtocolException e) {
+			LOGGER.error("exit()", e);
+		}
+	}
+
+	/**
+	 * safeExit: Puts Jenkins into the quiet mode, wait for existing builds to
+	 * be completed, and then shut down Jenkins
+	 * 
+	 * @param crumbFlag
+	 *            <code>true</code> to add <b>crumbIssuer</b> <code>false</code>
+	 *            otherwise.
+	 * @throws IOException
+	 *             in case of an error.
+	 */
+	public void safeExit(Boolean crumbFlag) throws IOException {
+		try {
+			client.post("/safeExit", crumbFlag);
+		} catch (org.apache.http.client.ClientProtocolException e) {
+			LOGGER.error("safeExit()", e);
+		}
+	}
 }


### PR DESCRIPTION
Added support for Stopping and Restarting Jenkins

- restart : Restart Jenkins without waiting for any existing build to complete

- safeRestart : Puts Jenkins into the quiet mode, wait for existing builds to be completed, and then restart Jenkins

- exit : Shutdown Jenkins without waiting for any existing build to complete

- safeExit : Puts Jenkins into the quiet mode, wait for existing builds to be completed, and then shut down Jenkins