### PR TITLE
Fix #118: Avoid the unsafe cast in Build#Stop()

### DIFF
--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/model/Build.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/model/Build.java
@@ -140,13 +140,13 @@ public class Build extends BaseModel {
         try {
 
             return client.get(url + "stop");
-        } catch (IOException ex) {
-            if (((HttpResponseException) ex).getStatusCode() == 405) {
+        } catch (HttpResponseException ex) {
+            if (ex.getStatusCode() == 405) {
                 stopPost();
                 return "";
             }
+            throw ex;
         }
-        return "";
     }
 
     /** Stops the build which is currently in progress.  This version takes in
@@ -163,13 +163,13 @@ public class Build extends BaseModel {
         try {
 
             return client.get(url + "stop");
-        } catch (IOException ex) {
-            if (((HttpResponseException) ex).getStatusCode() == 405) {
+        } catch (HttpResponseException ex) {
+            if (ex.getStatusCode() == 405) {
                 stopPost(crumbFlag);
                 return "";
             }
+            throw ex;
         }
-        return "";
     }
 
     private void stopPost(boolean crumbFlag) throws HttpResponseException, IOException {


### PR DESCRIPTION
- Recover when 405 is returned
- Propagate other exceptions correctly