### PR TITLE
Fixed #362

### DIFF
--- a/jenkins-client-it-docker/README.md
+++ b/jenkins-client-it-docker/README.md
@@ -12,6 +12,21 @@ The `plugin.txt` contains the list of plugins which will be installed
 during the build of the image.
 Those plugins are needed for the integration tests.
 
+How to run the Docker ITs on Windows (w/o Hyper-V)
+----
+  * [install Docker Toolbox][2] to get VirtualBox and Docker QuickStart 
+    Terminal onto your host system
+  * open Docker QuickStart Terminal and execute 
+    * `cd jenkins-client-it-docker`
+    * `docker build --no-cache -t jenkins-with-plugins .`
+    * note the IP address assigned to your "default" machine
+  * edit the configuration of the VirtualBox machine and add a new shared 
+    folder in the VirtualBox instance with the name "jobs" that points to 
+    "java-client-api\jenkins-client-it-docker\jobs"
+  * open Docker QuickStart Terminal and execute 
+    * `docker run --name jenkins-for-testing -v /jobs:/var/jenkins_home/jobs -d -p 8080:8080 -p 50000:50000  --env JENKINS_OPTS=--httpPort=8080 jenkins-with-plugins`
+    * `mvn -Prun-its,run-docker-its clean verify --batch-mode -DjenkinsUrl=http://[IP-address-of-the-docker-default-machine]:8080/`
+
 
 TODO
 ----
@@ -36,3 +51,4 @@ STATUS
 [issue-119]: https://github.com/jenkinsci/java-client-api//issues/119
 [pr-99]: https://github.com/jenkinsci/java-client-api//pull/99
 [pr-127]: https://github.com/jenkinsci/java-client-api//pull/127
+[2]: https://docs.docker.com/toolbox/overview/

--- a/jenkins-client-it-docker/src/test/java/com/offbytwo/jenkins/integration/AbstractJenkinsIntegrationCase.java
+++ b/jenkins-client-it-docker/src/test/java/com/offbytwo/jenkins/integration/AbstractJenkinsIntegrationCase.java
@@ -1,8 +1,10 @@
 package com.offbytwo.jenkins.integration;
 
+import java.net.URI;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.apache.commons.lang.StringUtils;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Listeners;
 
@@ -10,6 +12,9 @@ import com.offbytwo.jenkins.JenkinsServer;
 
 @Listeners({ MethodListener.class })
 public class AbstractJenkinsIntegrationCase {
+
+    // use mvn -Prun-its,run-docker-its clean verify --batch-mode -DjenkinsUrl=http://192.168.99.100:8080/
+    private static final String JENKINS_URL_PROPERTY = "jenkinsUrl";
 
     protected static JenkinsServer jenkinsServer;
 
@@ -21,9 +26,10 @@ public class AbstractJenkinsIntegrationCase {
 
     @BeforeSuite
     public void waitUntilJenkinsHasBeenStartedUp() throws TimeoutException {
+        URI jenkinsURI = getJenkinsURI();
+        jenkinsServer = new JenkinsServer(jenkinsURI);
+        System.out.print("Wait until Jenkins is started at [" + jenkinsURI + "]...");
         final long start = System.currentTimeMillis();
-        jenkinsServer = new JenkinsServer(Constant.JENKINS_URI);
-        System.out.print("Wait until Jenkins is started...");
         while (!jenkinsServer.isRunning() && !timeOut(start)) {
             try {
                 System.out.print(".");
@@ -39,6 +45,11 @@ public class AbstractJenkinsIntegrationCase {
         }
 
         System.out.println("done.");
+    }
+
+    private URI getJenkinsURI() {
+        String jenkinsUrlProperty = System.getProperty(JENKINS_URL_PROPERTY);
+        return StringUtils.isEmpty(jenkinsUrlProperty) ? Constant.JENKINS_URI : URI.create(jenkinsUrlProperty);
     }
 
     /**


### PR DESCRIPTION
- allow overwriting the default URL for the Jenkins server on the command line by passing "-DjenkinsUrl=http://something:8080"