### PR TITLE
Fix JENKINS-56585 change to post method

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -64,6 +64,11 @@
       assignedLabel.getName()
     }
    ```
+   
+ * [JENKINS-56585][jissue-56585]
+ 
+   Change request method of `QuietDown()` to POST
+
 
 ## Release 0.3.8
 
@@ -1164,3 +1169,4 @@ TestReport testReport = mavenJob.getLastSuccessfulBuild().getTestReport();
 [jissue-46445]: https://issues.jenkins-ci.org/browse/JENKINS-46445
 [jissue-46472]: https://issues.jenkins-ci.org/browse/JENKINS-46472
 [jissue-56186]: https://issues.jenkins-ci.org/browse/JENKINS-56186
+[jissue-56585]: https://issues.jenkins-ci.org/browse/JENKINS-56585

--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
@@ -649,7 +649,7 @@ public class JenkinsServer implements Closeable {
      */
     public void quietDown() throws IOException {
         try {
-            client.get("/quietDown/");
+            client.post("/quietDown/");
         } catch (org.apache.http.client.ClientProtocolException e) {
             LOGGER.error("quietDown()", e);
         }


### PR DESCRIPTION
Use GET to send Quiet Down message would return 405 Method Not Allowed.