### PR TITLE
Upgrading dom4j version

### DIFF
--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/model/BuildWithDetails.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/model/BuildWithDetails.java
@@ -407,7 +407,7 @@ public class BuildWithDetails extends Build {
      * @throws IOException in case of an error.
      *
      */
-    public void streamConsoleOutput(final BuildConsoleStreamListener listener, final int poolingInterval, final int poolingTimeout) throws InterruptedException, IOException {
+    public void streamConsoleOutput(final BuildConsoleStreamListener listener, final int poolingInterval, final int poolingTimeout, boolean crumbFlag) throws InterruptedException, IOException {
         // Calculate start and timeout
         final long startTime = System.currentTimeMillis();
         final long timeoutTime = startTime + (poolingTimeout * 1000);
@@ -417,7 +417,7 @@ public class BuildWithDetails extends Build {
             Thread.sleep(poolingInterval * 1000);
 
             ConsoleLog consoleLog = null;
-            consoleLog = getConsoleOutputText(bufferOffset);
+            consoleLog = getConsoleOutputText(bufferOffset, crumbFlag);
             String logString = consoleLog.getConsoleLog();
             if (logString != null && !logString.isEmpty()) {
                 listener.onData(logString);
@@ -447,11 +447,11 @@ public class BuildWithDetails extends Build {
      * {@code CR+LF}.
      * @throws IOException in case of a failure.
      */
-    public ConsoleLog getConsoleOutputText(int bufferOffset) throws IOException {
+    public ConsoleLog getConsoleOutputText(int bufferOffset, boolean crumbFlag) throws IOException {
         List<NameValuePair> formData = new ArrayList<>();
         formData.add(new BasicNameValuePair("start", Integer.toString(bufferOffset)));
         String path = getUrl() + "logText/progressiveText";
-        HttpResponse httpResponse = client.post_form_with_result(path, formData, false);
+        HttpResponse httpResponse = client.post_form_with_result(path, formData, crumbFlag);
 
         Header moreDataHeader = httpResponse.getFirstHeader(MORE_DATA_HEADER);
         Header textSizeHeader = httpResponse.getFirstHeader(TEXT_SIZE_HEADER);

--- a/jenkins-client/src/test/java/com/offbytwo/jenkins/model/BuildWithDetailsTest.java
+++ b/jenkins-client/src/test/java/com/offbytwo/jenkins/model/BuildWithDetailsTest.java
@@ -52,7 +52,7 @@ public class BuildWithDetailsTest extends BaseUnitTest {
             given(response.getFirstHeader(BuildWithDetails.MORE_DATA_HEADER)).willReturn(moreDataHeader);
             given(response.getFirstHeader(BuildWithDetails.TEXT_SIZE_HEADER)).willReturn(textSizeHeader);
             given(client.post_form_with_result(anyString(),anyListOf(NameValuePair.class),anyBoolean())).willReturn(response);
-            ConsoleLog consoleOutputText = buildWithDetails.getConsoleOutputText(500);
+            ConsoleLog consoleOutputText = buildWithDetails.getConsoleOutputText(500, false);
             assertThat(consoleOutputText.getConsoleLog()).isEqualTo(text);
             assertThat(consoleOutputText.getCurrentBufferSize()).isEqualTo(textLength);
             assertThat(consoleOutputText.getHasMoreData()).isFalse();
@@ -86,7 +86,7 @@ public class BuildWithDetailsTest extends BaseUnitTest {
                 public void finished() {
                     assertThat(buffer.toString()).isEqualTo(text);
                 }
-            },1,2);
+            },1,2, false);
         } catch (IOException e) {
             fail("Should not return exception",e);
         }
@@ -114,7 +114,7 @@ public class BuildWithDetailsTest extends BaseUnitTest {
                 public void finished() {
                     fail("Should timeout");
                 }
-            },1,2);
+            },1,2, false);
         } catch (IOException e) {
             fail("Should not return exception",e);
         }


### PR DESCRIPTION
According to NexusIQ and National Vulnerability Database dom4j.dom4j:1.6.1 contains [CVE-2018-1000632](https://nvd.nist.gov/vuln/detail/CVE-2018-1000632) vulnerability.
It is nesessary to upgrade dom4j up to 2.1.1 version with groupId changing to resolve it.