### PR TITLE
update jackson from 2.9.8 to 2.9.9 CVE-2019-12086

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <httpclient.version>4.5.8</httpclient.version>
     <httpcore.version>4.4.11</httpcore.version>
     <httpmime.version>4.5.8</httpmime.version>
-    <jackson-databind.version>2.9.8</jackson-databind.version>
+    <jackson-databind.version>2.9.9</jackson-databind.version>
   </properties>
 
   <licenses>


### PR DESCRIPTION
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.9