### PR TITLE
Fixed JENKINS-59379:  Update jackson via BOM import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <httpclient.version>4.5.8</httpclient.version>
     <httpcore.version>4.4.11</httpcore.version>
     <httpmime.version>4.5.8</httpmime.version>
-    <jackson-databind.version>2.9.9</jackson-databind.version>
+    <jackson.version>2.9.9.20190807</jackson.version>
   </properties>
 
   <licenses>
@@ -88,20 +88,11 @@
     <dependencies>
       <!-- Marshalling -->
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>${jackson-databind.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>${jackson-databind.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${jackson-databind.version}</version>
+          <groupId>com.fasterxml.jackson</groupId>
+          <artifactId>jackson-bom</artifactId>
+          <version>${jackson.version}</version>
+          <type>pom</type>
+          <scope>import</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
* Change property name from jackson-databind.version to jackson.version
* Replace jackson modules in dependencyManagement by jackson-bom POM import
* Use version 2.9.9.20190807.  This gives jackson-databind 2.9.9.3 with fixes for four CVE
  * [CVE-2019-14379](https://nvd.nist.gov/vuln/detail/2019-14379) (9.8)
  * [CVE-2019-14439](https://nvd.nist.gov/vuln/detail/2019-14439) (7.5)
  * [CVE-2019-12384](https://nvd.nist.gov/vuln/detail/2019-12384) (5.9)
  * [CVE-2019-12814](https://nvd.nist.gov/vuln/detail/2019-12814) (5.9)