### PR TITLE
Could com.offbytwo.jenkins:jenkins-client-it-docker:0.4.0-SNAPSHOT drop off redundant dependencies to loose weight? 

### DIFF
--- a/jenkins-client-it-docker/pom.xml
+++ b/jenkins-client-it-docker/pom.xml
@@ -22,6 +22,60 @@
       <groupId>com.offbytwo.jenkins</groupId>
       <artifactId>jenkins-client</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.sf.json-lib</groupId>	
+          <artifactId>json-lib</artifactId>	
+        </exclusion>
+        <exclusion>		
+          <groupId>com.fasterxml.jackson.core</groupId>	
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>		
+          <groupId>jaxen</groupId>
+          <artifactId>jaxen</artifactId>
+        </exclusion>
+        <exclusion>		
+          <groupId>com.fasterxml.jackson.core</groupId>		
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>	
+          <groupId>org.apache.commons</groupId>	
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
+        <exclusion>	
+          <groupId>org.dom4j</groupId>
+          <artifactId>dom4j</artifactId>
+        </exclusion>
+        <exclusion>	
+          <groupId>commons-io</groupId>	
+          <artifactId>commons-io</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpmime</artifactId>
+        </exclusion>
+        <exclusion>	
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>	
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>	
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-lang</groupId>	
+          <artifactId>commons-lang</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
 

--- a/jenkins-client-it-docker/pom.xml
+++ b/jenkins-client-it-docker/pom.xml
@@ -55,14 +55,6 @@
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpcore</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>	
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
         <exclusion>	
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>

--- a/jenkins-client-it-docker/pom.xml
+++ b/jenkins-client-it-docker/pom.xml
@@ -23,10 +23,6 @@
       <artifactId>jenkins-client</artifactId>
       <version>${project.version}</version>
       <exclusions>
-        <exclusion>
-          <groupId>net.sf.json-lib</groupId>	
-          <artifactId>json-lib</artifactId>	
-        </exclusion>
         <exclusion>		
           <groupId>com.fasterxml.jackson.core</groupId>	
           <artifactId>jackson-core</artifactId>


### PR DESCRIPTION
@khmarbaise Hi, I am a user of project **_com.offbytwo.jenkins:jenkins-client-it-docker:0.4.0-SNAPSHOT_**. I found that its pom file introduced **_30_** dependencies. However, among them, **_12_** libraries (**_40%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package.
This PR helps **_com.offbytwo.jenkins:jenkins-client-it-docker:0.4.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.
 Best regards   
## Redundant dependencies---
<pre><code>com.fasterxml.jackson.core:jackson-databind:jar:2.10.3:compile 
org.apache.commons:commons-lang3:jar:3.9:compile 
org.apache.httpcomponents:httpcore:jar:4.4.11:compile 
commons-io:commons-io:jar:2.4:compile 
org.apache.httpcomponents:httpmime:jar:4.5.8:compile 
org.dom4j:dom4j:jar:2.1.3:compile 
commons-lang:commons-lang:jar:2.5:compile 
com.fasterxml.jackson.core:jackson-core:jar:2.10.3:compile 
commons-logging:commons-logging:jar:1.2:compile 
jaxen:jaxen:jar:1.1.6:compile </code></pre>