### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <httpcore.version>4.4.11</httpcore.version>
     <httpmime.version>4.5.8</httpmime.version>
     <jackson-databind.version>2.10.3</jackson-databind.version>
+  	<closeTestReports>true</closeTestReports>
   </properties>
 
   <licenses>
@@ -255,6 +256,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.22.2</version>
+          <configuration>
+          	<parallel>classes</parallel>
+          	<useUnlimitedThreads>true</useUnlimitedThreads>
+          	<disableXmlReport>${closeTestReports}</disableXmlReport>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
According to [Maven parallel test](https://www.baeldung.com/maven-junit-parallel-tests), we can run tests in parallel.

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
