### PR TITLE
QueueId missing is fixed #496

### DIFF
--- a/jenkins-client/pom.xml
+++ b/jenkins-client/pom.xml
@@ -113,6 +113,11 @@
       <groupId>xerces</groupId>
       <artifactId>xmlParserAPIs</artifactId>
     </dependency>
+      <dependency>
+          <groupId>jakarta.xml.bind</groupId>
+          <artifactId>jakarta.xml.bind-api</artifactId>
+          <version>2.3.3</version>
+      </dependency>
   </dependencies>
 
   <build>

--- a/jenkins-client/src/main/java/com/offbytwo/jenkins/model/Build.java
+++ b/jenkins-client/src/main/java/com/offbytwo/jenkins/model/Build.java
@@ -63,7 +63,7 @@ public class Build extends BaseModel {
     }
 
     public Build(Build from) {
-        this(from.getNumber(), from.getUrl());
+        this(from.getNumber(), from.getQueueId(), from.getUrl());
     }
 
     public Build(int number, String url) {


### PR DESCRIPTION
QueueId was missing when querying AllBuilds #496.
 
=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.

